### PR TITLE
feat: update pycasbin to 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # casbin-python-cli
 
-![PyPI - Python Version](https://img.shields.io/badge/python-3.6%2B-blue)
+![PyPI - Python Version](https://img.shields.io/badge/python-3.8%2B-blue)
 ![PyPI - License](https://img.shields.io/badge/license-Apache%202.0-green)
-![PyPI - PyCasbin Version](https://img.shields.io/badge/pycasbin-1.17.0%2B-orange)
+![PyPI - PyCasbin Version](https://img.shields.io/badge/pycasbin-2.3.0%2B-orange)
 
 ## Features
 
@@ -17,7 +17,7 @@
 
 ### Prerequisites
 
-- Python 3.6+
+- Python 3.8+
 - pip package manager
 
 ### Installation Methods
@@ -138,8 +138,8 @@ casbin-python-cli/
 
 ## Requirements
 
-- Python 3.6+
-- PyCasbin 1.17.0+
+- Python 3.8+
+- PyCasbin 2.3.0+
 
 ## License
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-casbin>=1.17.0  
+pycasbin>=2.3.0
 pytest>=7.0.0  
 pytest-cov>=4.0.0  

--- a/setup.py
+++ b/setup.py
@@ -31,12 +31,12 @@ setup(
     long_description_content_type="text/markdown",  
     packages=find_packages(),  
     install_requires=[  
-        "casbin>=1.17.0",  
+        "pycasbin>=2.3.0",  
     ],  
     entry_points={  
         'console_scripts': [  
             'casbin-cli=casbin_cli.client:main',  
         ],  
     },  
-    python_requires='>=3.6',  
+    python_requires='>=3.8',  
 )


### PR DESCRIPTION
feat: update pycasbin to 2.3.0
Pycasbin requires Python version 3.8+.