### PR TITLE
feat: use runtime version numbers instead of hard-coded values

### DIFF
--- a/casbin_cli/__version__.py
+++ b/casbin_cli/__version__.py
@@ -1,1 +1,21 @@
-__version__ = "1.0.0"
+import subprocess
+
+
+def get_base_tag():
+    try:
+        command = ["git", "describe", "--tags", "--abbrev=0"]
+
+        tag = subprocess.check_output(
+            command, text=True, stderr=subprocess.PIPE
+        ).strip()
+
+        if tag.startswith("v"):
+            return tag[1:]
+        return tag
+
+    except subprocess.CalledProcessError:
+        print("Error: Failed to find any git tags.")
+        return None
+
+
+__version__ = get_base_tag()

--- a/casbin_cli/client.py
+++ b/casbin_cli/client.py
@@ -26,7 +26,18 @@ class Client:
                 return ""    
             elif command_name in ['-v', '--version']:    
                 print(f"casbin-python-cli {__version__}")    
-                print("pycasbin 1.17.0")    
+                try:
+                    from importlib.metadata import version
+
+                    pycasbin_version = version("pycasbin")
+                except ImportError:
+                    try:
+                        from importlib_metadata import version
+
+                        pycasbin_version = version("pycasbin")
+                    except (ImportError, Exception):
+                        pycasbin_version = "unknown"
+                print(f"pycasbin {pycasbin_version}")
                 return ""  
             elif command_name == 'completion':  
                 if len(args) < 2:  


### PR DESCRIPTION
feat: use dynamic version instead of hardcoded value.
The original code hardcoded the versions of casbin-python-cli and pycasbin, which caused the displayed versions to be inconsistent with the actual versions. 
```python
__version__ = "1.0.0"

print("pycasbin 1.17.0")
```
The code has been updated to fetch the casbin-python-cli version from the Git commit tag and to dynamically retrieve the installed pycasbin package version from the current environment.